### PR TITLE
Add metadata.template to azure.yaml

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -1,5 +1,5 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
-
 name: logicapp-consumption
 infra:
-    provider: "bicep"
+  provider: bicep
+metadata:
+  template: logicapp-consumption@0.0.1-beta


### PR DESCRIPTION
Adds  `metadata.template` tag for azd template discovery and telemetry tracking.

This is a minimal change generated by template-doctor validation tooling.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>